### PR TITLE
Generate report even output path has unexisted dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-test/*-output.xml
+test/**/*-output.xml
 .idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,10 @@ module.exports = function(grunt) {
         path: 'test/fixtures/',
         output: 'test/js-exclude-array-output.xml',
         exclude: ['file_2.js', 'file_3.js']
+      },
+      javascriptWithUnexistedOutputDir: {
+        path: 'test/fixtures/',
+        output: 'test/unexisted/output/dir/js-output.xml'
       }
     },
 

--- a/tasks/jscpd.js
+++ b/tasks/jscpd.js
@@ -12,6 +12,17 @@ module.exports = function(grunt) {
     }
   }
 
+  function ensureOutputDir(options) {
+    if (options.output) {
+      options.output = grunt.template.process(options.output);
+      var path = require("path");
+      var destDir = path.dirname(options.output);
+      if (!grunt.file.exists(destDir)) {
+        grunt.file.mkdir(destDir)
+      }
+    }
+  }
+
   grunt.registerMultiTask('jscpd', 'Find copy/paste', function() {
   
     var options = this.options({
@@ -23,6 +34,7 @@ module.exports = function(grunt) {
     options.output = this.data.output;
 
     ensureCleanPath(options);
+    ensureOutputDir(options);
 
     try {
       var instance = new jscpd();

--- a/test/test-jscpd.js
+++ b/test/test-jscpd.js
@@ -15,6 +15,12 @@ describe("Grunt JSCPD", function() {
 
     });
 
+    it("Generates non-empty file with JSCPD results in unexisted output dir", function () {
+
+      expect("test/unexisted/output/dir/js-output.xml").to.be.a.file().and.not.empty;
+
+    });
+
     var javascriptOutput = fs.readFileSync("test/js-output.xml", 'utf8');
     it("Identifies code duplication in 'file_3.js'", function() {
 


### PR DESCRIPTION
Bonjour Mazerte,

I need to create cpd report in a `output` path which contains some unexisted dirs, for example: `../reports/jscpd_report/cpd.xml`, here `../reports/jscpd_report/` is not existed before running grunt task.
Saddly `jscpd` fails when the `output` path contains unexisted dir.
So I fix it using `grunt.file.*` apis.
And I add mocha test this time :)

I hope my commit will help others with the same demand.

Sincèrement,
Antoine Duan
