### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/mazerte/grunt-jscpd"
+    "url": "git+https://github.com/mazerte/grunt-jscpd.git"
   },
   "keywords": [
     "grunt",


### PR DESCRIPTION
## Summary
- switch the npm `repository.url` from the legacy `git://` protocol to `git+https://`

## Why
The published npm metadata currently points at `git://github.com/mazerte/grunt-jscpd.git`. The `git://` protocol is legacy and often blocked by modern networks, while `git+https://` works without opening the unauthenticated git transport.

## Validation
- Parsed `package.json` as JSON.
- Ran `git diff --check`.
